### PR TITLE
Add human-readable channel names to newsletter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ MONGO_DB_NAME=discord-newsletter
 # Discord Configuration
 DISCORD_TOKEN=your-discord-token-here
 GUILD_CHANNELS=guildId1:channelId1,guildId2:channelId2
+DISCORD_GUILD_ID=your-guild-id
+DISCORD_CHANNEL_IDS=channelId1,channelId2,channelId3
+NEWSLETTER_RECIPIENTS=user1@example.com,user2@example.com
 
 # Authentication Configuration
 GOOGLE_PROJECT_ID=your-project-id

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Fetches messages from Discord channels, summarizes them using AI, and emails the
 - **Discord Integration**: Connects to Discord API to fetch messages
 - **OpenAI Integration**: Uses OpenAI API for message summarization
 - **Mailgun Integration**: Sends email summaries via Mailgun API
+- **Newsletter**: Weekly digest of Discord messages with human-readable channel names
 - **Authentication**: Built-in auth middleware with test environment support
 - **Testing**: Comprehensive test setup with tape and supertest
 - **Error Handling**: Automatic error catching and formatting
@@ -41,8 +42,11 @@ AUTHENTIC_SERVER=your-authentic-server # Optional for authentication
 WHITELIST=email1@example.com,email2@example.com # Optional for authentication
 
 # Discord Configuration
-DISCORD_BOT_TOKEN=your_discord_bot_token
-DISCORD_CHANNEL_ID=your_discord_channel_id
+DISCORD_TOKEN=your_discord_token_here
+GUILD_CHANNELS=guildId1:channelId1,guildId2:channelId2
+DISCORD_GUILD_ID=your_guild_id
+DISCORD_CHANNEL_IDS=channelId1,channelId2,channelId3
+NEWSLETTER_RECIPIENTS=user1@example.com,user2@example.com
 
 # OpenAI Configuration
 OPENAI_API_KEY=your_openai_api_key
@@ -118,6 +122,15 @@ npm start
 - `POST /email-summary` - Send the generated summary via email using Mailgun
 
 *(Authentication might be required for some endpoints depending on the setup)*
+
+## Scripts 📜
+
+- `npm run dev` - Start the development server with auto-restart
+- `npm start` - Start the production server
+- `npm test` - Run the test suite
+- `node scripts/send-newsletter.js` - Send a weekly newsletter with Discord messages
+- `node scripts/send-daily-summary.js` - Send a daily summary of Discord messages
+- `node scripts/archive-messages.js` - Archive messages from Discord to the database
 
 ## Code Style 📝
 

--- a/lib/newsletter/index.js
+++ b/lib/newsletter/index.js
@@ -1,0 +1,249 @@
+const { Client, GatewayIntentBits } = require('discord.js')
+const config = require('../../config')
+const email = require('../email')
+
+// Initialize Discord client with necessary intents
+const client = new Client({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent
+  ]
+})
+
+// Configuration
+const GUILD_ID = process.env.DISCORD_GUILD_ID
+const CHANNEL_IDS = (process.env.DISCORD_CHANNEL_IDS || '').split(',')
+const EMAIL_FROM = config.mailgunFrom
+const EMAIL_TO = (process.env.NEWSLETTER_RECIPIENTS || '').split(',')
+
+/**
+ * Sends a weekly newsletter with messages from configured Discord channels
+ */
+async function sendNewsletter() {
+  try {
+    const guild = await client.guilds.fetch(GUILD_ID)
+    const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+    
+    let allMessages = []
+    let channelNames = [] // New array to track channel names
+    
+    for (const channelId of CHANNEL_IDS) {
+      try {
+        const channel = await guild.channels.fetch(channelId)
+        if (!channel || !channel.isTextBased()) continue
+        
+        channelNames.push(channel.name) // Save the channel name
+        const messages = await fetchChannelMessages(channel, oneWeekAgo)
+        allMessages = allMessages.concat(messages)
+      } catch (error) {
+        console.error(`Error fetching messages from channel ${channelId}:`, error)
+      }
+    }
+    
+    // Pass channelNames to sendEmail
+    const html = generateEmailHTML(allMessages, oneWeekAgo)
+    await sendEmail(html, oneWeekAgo, channelNames)
+    
+  } catch (error) {
+    console.error('Error sending newsletter:', error)
+  }
+}
+
+/**
+ * Fetches messages from a Discord channel since a specified date
+ * @param {Object} channel - Discord channel object
+ * @param {Date} since - Date to fetch messages from
+ * @returns {Array} Array of message objects
+ */
+async function fetchChannelMessages(channel, since) {
+  const messages = []
+  let lastMessageId = null
+  
+  while (true) {
+    const options = { limit: 100 }
+    if (lastMessageId) options.before = lastMessageId
+    
+    const fetchedMessages = await channel.messages.fetch(options)
+    if (fetchedMessages.size === 0) break
+    
+    for (const message of fetchedMessages.values()) {
+      if (message.createdAt < since) {
+        return messages // Stop when we reach messages older than our timeframe
+      }
+      
+      // Check if message meets criteria
+      if (await shouldIncludeMessage(message)) {
+        messages.push({
+          content: message.content,
+          author: message.author.username,
+          timestamp: message.createdAt,
+          channelId: message.channel.id,
+          channelName: message.channel.name, // Add channel name
+          url: message.url,
+          reactions: message.reactions.cache.map(r => ({
+            emoji: r.emoji.toString(),
+            count: r.count
+          }))
+        })
+      }
+    }
+    
+    lastMessageId = fetchedMessages.last().id
+  }
+  
+  return messages
+}
+
+/**
+ * Determines if a message should be included in the newsletter
+ * @param {Object} message - Discord message object
+ * @returns {Boolean} Whether to include the message
+ */
+async function shouldIncludeMessage(message) {
+  // Skip bot messages
+  if (message.author.bot) return false
+  
+  // Skip messages with no content
+  if (!message.content && message.attachments.size === 0 && message.embeds.length === 0) return false
+  
+  // Include messages with reactions or attachments
+  if (message.reactions.cache.size > 0 || message.attachments.size > 0) return true
+  
+  // Include messages with substantial content
+  if (message.content.length > 20) return true
+  
+  return false
+}
+
+/**
+ * Generates HTML for the newsletter email
+ * @param {Array} messages - Array of message objects
+ * @param {Date} since - Start date for the newsletter
+ * @returns {String} HTML content for the email
+ */
+function generateEmailHTML(messages, since) {
+  // Group messages by channelId, but also store the channel name
+  const groupedMessages = messages.reduce((acc, msg) => {
+    if (!acc[msg.channelId]) {
+      acc[msg.channelId] = {
+        name: msg.channelName,
+        messages: []
+      }
+    }
+    acc[msg.channelId].messages.push(msg)
+    return acc
+  }, {})
+  
+  let html = `
+    <html>
+      <head>
+        <style>
+          body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+          .channel { margin-bottom: 30px; }
+          .channel-header { background: #7289da; color: white; padding: 10px; border-radius: 5px; }
+          .message { margin: 15px 0; padding: 15px; background: #f4f4f4; border-radius: 5px; }
+          .author { font-weight: bold; color: #7289da; }
+          .timestamp { color: #666; font-size: 0.9em; }
+          .reactions { margin-top: 10px; }
+          .reaction { display: inline-block; margin-right: 10px; padding: 2px 8px; background: #fff; border-radius: 3px; }
+        </style>
+      </head>
+      <body>
+        <h1>Discord Newsletter</h1>
+        <p>Messages from ${since.toLocaleDateString()} to ${new Date().toLocaleDateString()}</p>
+  `
+  
+  for (const [channelId, channelData] of Object.entries(groupedMessages)) {
+    html += `
+      <div class="channel">
+        <h2 class="channel-header">Channel: #${channelData.name}</h2>
+    `
+    
+    for (const msg of channelData.messages.sort((a, b) => a.timestamp - b.timestamp)) {
+      html += `
+        <div class="message">
+          <div>
+            <span class="author">${msg.author}</span>
+            <span class="timestamp">${msg.timestamp.toLocaleString()}</span>
+          </div>
+          <p>${msg.content}</p>
+          ${msg.reactions.length > 0 ? `
+            <div class="reactions">
+              ${msg.reactions.map(r => `<span class="reaction">${r.emoji} ${r.count}</span>`).join('')}
+            </div>
+          ` : ''}
+          <a href="${msg.url}">View in Discord</a>
+        </div>
+      `
+    }
+    
+    html += '</div>'
+  }
+  
+  html += `
+      </body>
+    </html>
+  `
+  
+  return html
+}
+
+/**
+ * Sends the newsletter email
+ * @param {String} html - HTML content for the email
+ * @param {Date} since - Start date for the newsletter
+ * @param {Array} channelNames - Array of channel names
+ */
+async function sendEmail(html, since, channelNames) {
+  const dateRange = `${since.toLocaleDateString()} to ${new Date().toLocaleDateString()}`
+  
+  // Format channel names for the subject
+  const channelNamesStr = channelNames.length > 0 
+    ? channelNames.map(name => `#${name}`).join(', ') 
+    : 'Discord'
+  
+  const options = {
+    to: EMAIL_TO.join(','),
+    subject: `${channelNamesStr} ${dateRange} Discord Newsletter`,
+    html: html
+  }
+  
+  try {
+    const response = await email.sendEmail(options)
+    console.log('Newsletter sent successfully:', response)
+    return response
+  } catch (error) {
+    console.error('Error sending newsletter:', error)
+    throw error
+  }
+}
+
+/**
+ * Initializes the Discord client and logs in
+ */
+async function init() {
+  if (!process.env.DISCORD_TOKEN) {
+    throw new Error('DISCORD_TOKEN environment variable is required')
+  }
+  
+  if (!GUILD_ID) {
+    throw new Error('DISCORD_GUILD_ID environment variable is required')
+  }
+  
+  if (!CHANNEL_IDS || CHANNEL_IDS.length === 0 || CHANNEL_IDS[0] === '') {
+    throw new Error('DISCORD_CHANNEL_IDS environment variable is required')
+  }
+  
+  if (!EMAIL_TO || EMAIL_TO.length === 0 || EMAIL_TO[0] === '') {
+    throw new Error('NEWSLETTER_RECIPIENTS environment variable is required')
+  }
+  
+  await client.login(process.env.DISCORD_TOKEN)
+  console.log(`Logged in as ${client.user.tag}`)
+}
+
+module.exports = {
+  init,
+  sendNewsletter
+}

--- a/scripts/send-newsletter.js
+++ b/scripts/send-newsletter.js
@@ -1,0 +1,23 @@
+const newsletter = require('../lib/newsletter')
+
+async function main() {
+  try {
+    console.log('Initializing Discord client...')
+    await newsletter.init()
+    
+    console.log('Sending newsletter...')
+    await newsletter.sendNewsletter()
+    
+    console.log('Newsletter sent successfully!')
+    process.exit(0)
+  } catch (error) {
+    console.error('Error sending newsletter:', error)
+    process.exit(1)
+  }
+}
+
+if (require.main === module) {
+  main()
+}
+
+module.exports = main


### PR DESCRIPTION
Fixes #4

This PR implements the requested feature to use human-readable channel names in the Discord newsletter instead of channel IDs. The changes include:

- Created a new newsletter module that fetches messages from Discord channels
- Added functionality to track channel names alongside channel IDs
- Updated email templates to display channel names instead of IDs
- Added a new script to send weekly newsletters
- Updated documentation and environment variable examples

The implementation follows the step-by-step instructions provided in the issue.